### PR TITLE
Fixes existing warnings and notes from R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: log4r
 Type: Package
-Title: A simple logging system for R, based on log4j.
+Title: A simple logging system for R, based on log4j
 Version: 0.2
 Date: 2014-09-29
 Authors@R: c( person("John Myles", "White", role = c("aut", "cph")),

--- a/R/logfuncs.R
+++ b/R/logfuncs.R
@@ -16,7 +16,7 @@
 #' info(logger, 'Information about our code')
 #' warn(logger, 'Another warning from our code')
 #' error(logger, 'An error from our code')
-#' fatal(logger, 'I\'m outta here')
+#' fatal(logger, "I'm outta here")
 #' @export
 levellog <- function(logger, level, message) {
   level <- as.loglevel(level)

--- a/R/loglevel.R
+++ b/R/loglevel.R
@@ -98,7 +98,7 @@ as.character.loglevel <- function(x, ...) LEVEL_NAMES[[x]]
 
 #' @rdname loglevel
 #' @export
-available.loglevels <- function() lapply(setNames(nm = LEVEL_NAMES), loglevel)
+available.loglevels <- function() lapply(stats::setNames(nm = LEVEL_NAMES), loglevel)
 
 #' @rdname loglevel
 #' @export

--- a/man/levellog.Rd
+++ b/man/levellog.Rd
@@ -41,7 +41,7 @@ debug(logger, 'Debugging our code')
 info(logger, 'Information about our code')
 warn(logger, 'Another warning from our code')
 error(logger, 'An error from our code')
-fatal(logger, 'I\\'m outta here')
+fatal(logger, "I'm outta here")
 }
 \seealso{
 \code{\link{loglevel}}


### PR DESCRIPTION
This is a minor change fixing some cosmetic issues:

- A NOTE about the title ending in a period.
- A NOTE about the namespace of the 'setNames' function.
- A WARNING about mismatched quotes in the documentation.

`R CMD check` now reports a clean bill of health.

@krlmlr I mentioned on Twitter that I'm interesting in taking on maintainership of this package. How would you like that to work?