### PR TITLE
Create Trace logging level

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
 Encoding: UTF-8
 LazyLoad: yes
 Roxygen: list(old_usage = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr

--- a/R/logfuncs.R
+++ b/R/logfuncs.R
@@ -13,6 +13,7 @@
 #' logger <- create.logger(logfile = 'debugging.log', level = "WARN")
 #'
 #' levellog(logger, 'WARN', 'First warning from our code')
+#' trace(logger, "Extra debugging information")
 #' debug(logger, 'Debugging our code')
 #' info(logger, 'Information about our code')
 #' warn(logger, 'Another warning from our code')
@@ -24,6 +25,13 @@ levellog <- function(logger, level, ...) {
   if (logger$threshold > level) return(invisible(NULL))
   for (appender in logger$appenders) {
     appender(level, ...)
+  }
+}
+
+log_trace <- function(logger, ...) {
+  if (logger$threshold > TRACE) return(invisible(NULL))
+  for (appender in logger$appenders) {
+    appnder("TRACE", ...)
   }
 }
 
@@ -61,6 +69,10 @@ log_fatal <- function(logger, ...) {
     appender("FATAL", ...)
   }
 }
+
+#' @rdname levellog
+#' @export
+trace <- log_trace
 
 #' @rdname levellog
 #' @export

--- a/R/loglevel.R
+++ b/R/loglevel.R
@@ -1,5 +1,5 @@
 # Internal use only.
-LEVEL_NAMES <- c("DEBUG", "INFO", "WARN", "ERROR", "FATAL")
+LEVEL_NAMES <- c("TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL")
 LEVELS <- factor(LEVEL_NAMES, levels = LEVEL_NAMES, ordered = TRUE)
 
 #' Logging levels

--- a/R/loglevel.R
+++ b/R/loglevel.R
@@ -63,8 +63,14 @@ loglevel <- function(i)
     stop("loglevel accepts only atomic values")
 
   if (is.numeric(i)) {
-    i <- min(i, length(LEVELS))
+    if (i <= 0) {
+      i <- 1
+      return(structure(LEVELS[[i]], class = "loglevel"))
+    }
+    i <- min(i, length(LEVELS) - 1)
     i <- max(i, 1)
+    i <- i + 1 # bumps up number for TRACE
+    print
   } else if (is.character(i)) {
     name <- i
     i <- which(name == levels(LEVELS))
@@ -105,10 +111,11 @@ available.loglevels <- function() lapply(stats::setNames(nm = LEVEL_NAMES), logl
 verbosity <- function(v) {
   if (!is.numeric(v))
     stop("numeric expected")
-  loglevel(length(LEVELS) + 1 - v)
+  loglevel(length(LEVELS) - v)
 }
 
 # Deprecated.
+TRACE <- loglevel("TRACE")
 DEBUG <- loglevel("DEBUG")
 INFO <- loglevel("INFO")
 WARN <- loglevel("WARN")

--- a/tests/testthat/test-acceptance.R
+++ b/tests/testthat/test-acceptance.R
@@ -12,20 +12,23 @@ test_that('Logger levels', {
   logger <- create.logger()
   logfile(logger) <- file.path('base.log')
 
-  level(logger) <- log4r:::DEBUG
+  level(logger) <- log4r:::TRACE
   expect_true(level(logger) == 1)
 
-  level(logger) <- log4r:::INFO
+  level(logger) <- log4r:::DEBUG
   expect_true(level(logger) == 2)
 
-  level(logger) <- log4r:::WARN
+  level(logger) <- log4r:::INFO
   expect_true(level(logger) == 3)
 
-  level(logger) <- log4r:::ERROR
+  level(logger) <- log4r:::WARN
   expect_true(level(logger) == 4)
 
-  level(logger) <- log4r:::FATAL
+  level(logger) <- log4r:::ERROR
   expect_true(level(logger) == 5)
+
+  level(logger) <- log4r:::FATAL
+  expect_true(level(logger) == 6)
 
   unlink(logfile(logger))
 })

--- a/tests/testthat/test-loglevel.R
+++ b/tests/testthat/test-loglevel.R
@@ -1,8 +1,8 @@
 context("loglevel")
 
 test_that("The loglevel() constructor works as expected", {
-  expect_equal(loglevel(-19), DEBUG)
-  expect_equal(loglevel(-1), DEBUG)
+  expect_equal(loglevel(-19), TRACE)
+  expect_equal(loglevel(-1), TRACE)
   expect_equal(loglevel(1), DEBUG)
   expect_equal(loglevel(2), INFO)
   expect_equal(loglevel(3), WARN)
@@ -10,6 +10,7 @@ test_that("The loglevel() constructor works as expected", {
   expect_equal(loglevel(5), FATAL)
   expect_equal(loglevel(6), FATAL)
   expect_equal(loglevel(60), FATAL)
+  expect_equal(loglevel("TRACE"), TRACE)
   expect_equal(loglevel("DEBUG"), DEBUG)
   expect_equal(loglevel("INFO"), INFO)
   expect_equal(loglevel("WARN"), WARN)
@@ -24,11 +25,11 @@ test_that("The loglevel() constructor works as expected", {
 })
 
 test_that("Coercion works as expected", {
-  expect_equal(as.numeric(loglevel("DEBUG")), 1)
+  expect_equal(as.numeric(loglevel("DEBUG")), 2)
   expect_equal(as.character(loglevel("WARN")), "WARN")
   expect_equal(as.loglevel(loglevel("INFO")), loglevel("INFO"))
 })
 
 test_that("All log levels are available", {
-  expect_equal(unname(vapply(available.loglevels(), as.integer, integer(1))), 1:5)
+  expect_equal(unname(vapply(available.loglevels(), as.integer, integer(1))), 1:6)
 })

--- a/tests/testthat/test-verbosity.R
+++ b/tests/testthat/test-verbosity.R
@@ -8,6 +8,6 @@ test_that("The verbosity() constructor creates equivalent log levels", {
   expect_equal(verbosity(3), WARN)
   expect_equal(verbosity(4), INFO)
   expect_equal(verbosity(5), DEBUG)
-  expect_equal(verbosity(6), DEBUG)
-  expect_equal(verbosity(60), DEBUG)
+  expect_equal(verbosity(6), TRACE)
+  expect_equal(verbosity(60), TRACE)
 })


### PR DESCRIPTION
I was debugging some code today and I really wanted extra detail, but didn't want to clutter up the debug log with a ton of extras. So I thought about adding an extra logging level below debug, trace. 

My goals (which I think I succeeded on):

1. Add a trace level
2. Not impact `loglevel(1) == "DEBUG"`

I did have to modify some of the tests (which hopefully didn't break anything) to expect this extra level. The way I implemented goal 2 was to make it so TRACE had to be 0 or less. While this technically breaks people's code, I believe it doesn't impact users who set the level to 2 and expect just info. If you set the level to debug, but never use the trace feature.