### PR TITLE
Improve and modernise error reporting with `cli::cli_abort()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,9 @@ License: Artistic-2.0
 URL: https://github.com/johnmyleswhite/log4r
 BugReports: https://github.com/johnmyleswhite/log4r/issues
 Imports:
-    lifecycle
+    cli,
+    lifecycle,
+    rlang
 Suggests:
     futile.logger,
     httr,
@@ -28,7 +30,6 @@ Suggests:
     logging,
     loggit,
     microbenchmark,
-    rlang,
     rlog,
     rmarkdown,
     rsyslog,

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@
   `log_trace()` function in the future. The obscure `verbosity()` function is
   also now deprecated, for similar reasons.
 
+* Errors have been migrated to `cli::cli_abort()` and are now much friendlier
+  and actionable as a result.
+
 # log4r 0.4.4
 
 * Fixes failing unit tests for the HTTP appender.

--- a/R/level.R
+++ b/R/level.R
@@ -41,22 +41,23 @@ as_level <- function(i) {
     return(i)
   }
 
-  if (length(i) != 1) {
-    stop("The log level must be a string or single integer")
+  idx <- NULL
+  if (length(i) == 1 && is.numeric(i)) {
+    idx <- max(min(i, length(LEVELS)), 1)
+  } else if (length(i) == 1 && is.character(i)) {
+    idx <- which(i == levels(LEVELS))
   }
 
-  if (is.numeric(i)) {
-    i <- min(i, length(LEVELS))
-    i <- max(i, 1)
-  } else if (is.character(i)) {
-    name <- i
-    i <- which(name == levels(LEVELS))
-    if (length(i) == 0)
-      stop("unknown logging level: ", name)
-  } else
-    stop("cannot determine loglevel from ", typeof(i), " ", i)
+  if (length(idx) == 0) {
+    arg <- rlang::caller_arg(i)
+    levels <- cli::cli_vec(LEVEL_NAMES, style = list("vec-last" = ", or "))
+    cli::cli_abort(
+      "{.arg {arg}} must be one of {.str {levels}}.",
+      call = rlang::caller_env()
+    )
+  }
 
-  structure(LEVELS[[i]], class = "loglevel")
+  structure(LEVELS[idx], class = "loglevel")
 }
 
 # Internal constants.

--- a/R/logger.R
+++ b/R/logger.R
@@ -35,7 +35,7 @@ logger <- function(threshold = "INFO", appenders = console_appender()) {
     appenders <- list(appenders)
   }
   if (!all(vapply(appenders, is.function, logical(1)))) {
-    stop("Appenders must be functions.", call. = FALSE)
+    cli::cli_abort("{.arg appenders} must be a function or list of functions.")
   }
   appenders <- lapply(appenders, compiler::cmpfun)
   structure(

--- a/tests/testthat/test-layouts.R
+++ b/tests/testthat/test-layouts.R
@@ -57,5 +57,8 @@ test_that("JSON layouts work correctly", {
 })
 
 test_that("Wonky times formats are caught early", {
-  expect_error(default_log_layout(strrep("%Y", 30)), regex = "Invalid")
+  expect_error(
+    default_log_layout(strrep("%Y", 30)),
+    regexp = "must be a valid timestamp format string"
+  )
 })

--- a/tests/testthat/test-level.R
+++ b/tests/testthat/test-level.R
@@ -1,6 +1,6 @@
 test_that("The logger threshold works as expected", {
-  expect_error(logger(threshold = "UNKNOWN"), "unknown logging level")
-  expect_error(logger(threshold = NULL), "must be a string")
+  expect_error(logger(threshold = "UNKNOWN"), "must be one of")
+  expect_error(logger(threshold = NULL), "must be one of")
   lgr <- logger()
   level(lgr) <- "FATAL"
   expect_snapshot(level(lgr))
@@ -28,11 +28,9 @@ test_that("The loglevel() constructor works as expected", {
   expect_equal(loglevel("ERROR"), ERROR)
   expect_equal(loglevel("FATAL"), FATAL)
 
-  expect_error(loglevel("UNLOG"), "unknown logging level: UNLOG")
-  expect_error(loglevel("ATA"), "unknown logging level: ATA")
-  expect_error(loglevel("WAR"), "unknown logging level: WAR")
-  expect_error(loglevel(1:3), "must be a string")
-  expect_error(loglevel(FALSE), "cannot determine")
+  expect_error(loglevel("UNLOG"), "must be one of")
+  expect_error(loglevel(1:3), "must be one of")
+  expect_error(loglevel(FALSE), "must be one of")
 })
 
 test_that("Coercion works as expected", {


### PR DESCRIPTION
This generally results in much more friendly and actionable error messages.