### PR TITLE
Set up an `r-lib`-style pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,6 @@
 ^\.github$
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ upload.sh
 src/*.o
 src/*.so
 inst/doc
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: The log4r package is meant to provide a fast, lightweight,
   object-oriented approach to logging in R based on the widely-emulated
   'log4j' system and etymology.
 License: Artistic-2.0
-URL: https://github.com/johnmyleswhite/log4r
+URL: https://github.com/johnmyleswhite/log4r, https://log4r.r-lib.org
 BugReports: https://github.com/johnmyleswhite/log4r/issues
 Imports:
     cli,
@@ -48,3 +48,4 @@ Collate:
     'level.R'
     'log4r-package.R'
     'logger.R'
+Config/Needs/website: tidyverse/tidytemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,24 @@
+url: https://log4r.r-lib.org
+template:
+  package: tidytemplate
+  bootstrap: 5
+  includes:
+    in_header: |
+      <script defer data-domain="log4r.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+development:
+  mode: auto
+reference:
+- title: Basics
+  contents:
+  - logger
+  - log_at
+- title: Appenders
+  contents:
+  - appenders
+  - syslog_appender
+  - http_appender
+  - tcp_appender
+- title: Layouts
+  contents: layouts
+- title: Advanced
+  contents: level


### PR DESCRIPTION
This commit sets up pkgdown using the r-lib template.

It's basically the result of running `usethis::use_pkgdown_github_pages()`.